### PR TITLE
Исправление ошибки склонения отчеств с "Оглы"\"Кызы" в конце.

### DIFF
--- a/Cyriller/CyrName.cs
+++ b/Cyriller/CyrName.cs
@@ -116,7 +116,7 @@ namespace Cyriller
                 patronymic = patronymic.Substring(0, patronymic.Length - 5);
             }
 
-            if (patronymic.StartsWith("Оглы") || patronymic.StartsWith("Кызы"))
+            if (patronymic.EndsWith("оглы") || patronymic.EndsWith("кызы"))
             {
                 patronymicAfter = patronymic.Substring(patronymic.Length - 4);
                 patronymic = patronymic.Substring(0, patronymic.Length - 4);

--- a/Cyriller/CyrName.cs
+++ b/Cyriller/CyrName.cs
@@ -110,16 +110,10 @@ namespace Cyriller
                 patronymic = patronymic.Substring(4);
             }
 
-            if (patronymic.EndsWith("-оглы") || patronymic.EndsWith("-кызы"))
+            if (patronymic.EndsWith("оглы") || patronymic.EndsWith("кызы"))
             {
                 patronymicAfter = patronymic.Substring(patronymic.Length - 5);
                 patronymic = patronymic.Substring(0, patronymic.Length - 5);
-            }
-
-            if (patronymic.EndsWith("оглы") || patronymic.EndsWith("кызы"))
-            {
-                patronymicAfter = patronymic.Substring(patronymic.Length - 4);
-                patronymic = patronymic.Substring(0, patronymic.Length - 4);
             }
 
             if (caseNumber < 1 || caseNumber > 6)


### PR DESCRIPTION
Спасибо большое за ваш проект!
Нашел ошибку, при склонении имени с Оглы\Кызы, например склоняем в родительный падеж "Алиев Саркар Самед Оглы", в результаты получаем "Алиева Саркара Самед оглыа". 
Причина в том, что сначала отчество "Самед Оглы" преобразуется в "Самед оглы" в строке кода `patronymic = this.ProperCase(inputPatronymic);`
А далее проверяется есть ли в начале строки "patronymic" "Оглы" или "Кызы", а надо, как я понимаю, проверять есть ли в конце строки "оглы" или "кызы", по аналогии с проверкой "-оглы"\"-кызы". 
Это поправил, далее понял, что для упрощения достаточно только проверить есть ли "оглы"\"кызы" в конце строки, и если они есть, то разбить строку как это было в проверке "-оглы"\"-кызы":
```
patronymicAfter = patronymic.Substring(patronymic.Length - 5);
patronymic = patronymic.Substring(0, patronymic.Length - 5);
```

Этого достаточно для правильного срабатывания при обеих случаях записи окончания отчества, а проверка с дефисом смысла не имеет.